### PR TITLE
Rename and config routes

### DIFF
--- a/app/controllers/api/v1/checkIns.js
+++ b/app/controllers/api/v1/checkIns.js
@@ -4,19 +4,15 @@ const createError = require('http-errors');
 const CheckIn = require('../../../models/checkIn');
 const User = require('../../../models/user');
 
-const updateIsHome = async (req, res, next) => {
+const dismissBreach = async (req, res, next) => {
   try {
-    const isHome = req.body.isHome;
     const userId = req.decodedToken.id
     const checkInId = req.params.id;
-    if (isHome === undefined) {
-      throw createError(400, "isHome not provided")
-    }
     let checkIn = await CheckIn.getCheckInById(checkInId)
     if (checkIn.userId != userId) {
       throw createError(403, "Unauthorized")
     }
-    checkIn = await checkIn.updateIsHome(isHome);
+    checkIn = await checkIn.updateIsHome();
     const user = await User.getUserById(userId);
     userProfile = await user.recalculateStreak();
     res.json(userProfile);
@@ -26,4 +22,4 @@ const updateIsHome = async (req, res, next) => {
 }
 
 
-module.exports = { updateIsHome };
+module.exports = { dismissBreach };

--- a/app/models/checkIn.js
+++ b/app/models/checkIn.js
@@ -25,9 +25,9 @@ CheckInSchema.statics = {
 }
 
 CheckInSchema.methods = {
-  updateIsHome: async function (isHome) {
+  updateIsHome: async function () {
     try {
-      this.isHome = isHome
+      this.isHome = true
       return await this.save();
     } catch (err) {
       throw err

--- a/app/routes.js
+++ b/app/routes.js
@@ -18,8 +18,8 @@ router.use('/api/v1/checkIns', checkInsRouter);
 usersRouter.post('/authenticate', usersController.authenticate);
 usersRouter.patch('/updateNickName', authHelper.authenticate, usersController.updateNickName);
 usersRouter.get('/profile', authHelper.authenticate, usersController.getProfile);
-usersRouter.post('/updateAchievement', authHelper.authenticate, usersController.updateAchievement);
-usersRouter.post('/createCheckIn', authHelper.authenticate, usersController.createCheckIn)
+usersRouter.patch('/achievement', authHelper.authenticate, usersController.updateAchievement);
+usersRouter.post('/checkIn', authHelper.authenticate, usersController.createCheckIn)
 
 // checkin routes
 checkInsRouter.patch('/:id/dismissBreach', authHelper.authenticate, checkInsController.dismissBreach);

--- a/app/routes.js
+++ b/app/routes.js
@@ -22,6 +22,6 @@ usersRouter.post('/updateAchievement', authHelper.authenticate, usersController.
 usersRouter.post('/createCheckIn', authHelper.authenticate, usersController.createCheckIn)
 
 // checkin routes
-checkInsRouter.patch('/:id/updateIsHome', authHelper.authenticate, checkInsController.updateIsHome);
+checkInsRouter.patch('/:id/dismissBreach', authHelper.authenticate, checkInsController.dismissBreach);
 
 module.exports = router


### PR DESCRIPTION
Renamed some of the routes to make more sense

https://docs.google.com/document/d/15bgEGHz2xEAglY0-stXDTAbtx4cDg91GOzscltUqECM/edit

POST api/v1/users/updateAchievement --> PATCH api/v1/users/achievement
POST api/v1/users/createCheckIn --> POST api/v1/users/checkIn
PATCH api/v1/checkIns/:id/updateIsHome --> PATCH api/v1/checkIns/:id/dismissBreach

dismissBreach and will not require a body anymore since I don't need the boolean from the user (as user can only dismiss a breach, they can not do the reverse)